### PR TITLE
changed if condition in serialize_dict_field so it will not raise exception in case of empty dict field

### DIFF
--- a/flask_umongorest/resources.py
+++ b/flask_umongorest/resources.py
@@ -360,7 +360,7 @@ class Resource(object):
         (e.g. if the schema defines a DictField(IntField), where all
         the values in the dict should be ints).
         """
-        if field_instance.field:
+        if getattr(field_instance, "field", None):
             return {
                 key: self.get_field_value(elem, field_name, field_instance=field_instance.field, **kwargs)
                 for (key, elem) in field_value.items()


### PR DESCRIPTION
Under resources file, Modify the "serialize_dict_field" method so i he field property is missing, it will save the dict as is in the doc instead of throwing exception